### PR TITLE
feat!: add template slides

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Event controls provided by the widget:
 - `SimpleSlide`: removes abstraction of the `SlideWidget`.
 - `TitleSlide`: common title slide template containing `title` and `subtitle`.
 - `SectionHeader`: common section header template containing only `title`.
-- `BlankSlide`: a blank slide that only allows option for background widget.
+- `BlankSlide`: a slide that only allows option for background widget.
+- `BackgroundlessSlide`: a slide that only takes in slide widget.
 
 > More widgets to come in the upcoming releases.
 
@@ -204,6 +205,14 @@ TitleSlide.fromText(
 ),
 ```
 
+SectionHeader:
+```dart
+SectionHeader(title: TitleWidget()),
+
+// Use this constructor if you want to pass only string
+SectionHeader.fromText(title: 'Title'),
+```
+
 BlankSlide:
 ```dart
 BlankSlide(),
@@ -212,12 +221,9 @@ BlankSlide(),
 BlankSlide(background: BackgroundWidget()),
 ```
 
-SectionHeader:
+BackgroundlessSlide
 ```dart
-SectionHeader(title: TitleWidget()),
-
-// Use this constructor if you want to pass only string
-SectionHeader.fromText(title: 'Title'),
+BackgroundlessSlide(slide: ForegroundWidget()),
 ```
 
 You can have a look at the package default [example](https://github.com/immadisairaj/prides/tree/main/example) directory that contains an example with detailed usage of the widgets.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Event controls provided by the widget:
 - `SimpleSlide`: removes abstraction of the `SlideWidget`.
 - `TitleSlide`: common title slide template containing `title` and `subtitle`.
 - `SectionHeader`: common section header template containing only `title`.
+- `BlankSlide`: a blank slide that only allows option for background widget.
 
 > More widgets to come in the upcoming releases.
 
@@ -201,6 +202,14 @@ TitleSlide.fromText(
     title: 'Title',
     subtitle: 'Subtitle',
 ),
+```
+
+BlankSlide:
+```dart
+BlankSlide(),
+
+// use this if you want to show a unique background
+BlankSlide(background: BackgroundWidget()),
 ```
 
 SectionHeader:

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Event controls provided by the widget:
 
 - `SimpleSlide`: removes abstraction of the `SlideWidget`.
 - `TitleSlide`: common title slide template containing `title` and `subtitle`.
+- `SectionHeader`: common section header template containing only `title`.
 
 > More widgets to come in the upcoming releases.
 
@@ -200,6 +201,14 @@ TitleSlide.fromText(
     title: 'Title',
     subtitle: 'Subtitle',
 ),
+```
+
+SectionHeader:
+```dart
+SectionHeader(title: TitleWidget()),
+
+// Use this constructor if you want to pass only string
+SectionHeader.fromText(title: 'Title'),
 ```
 
 You can have a look at the package default [example](https://github.com/immadisairaj/prides/tree/main/example) directory that contains an example with detailed usage of the widgets.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -64,6 +64,9 @@ class MyHomePage extends StatelessWidget {
               child: Text('Blank Slide - This text is from background'),
             ),
           ),
+          const BackgroundlessSlide(
+            slide: Center(child: Text('Backgroundless Slide')),
+          ),
           const ExampleSlide(
             text: 'Flutter is Awesome!',
             backgroundColor: Colors.blue,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -36,6 +36,12 @@ class MyHomePage extends StatelessWidget {
             title: 'Title Slide',
             subtitle: 'This is a templete slide using fromText()',
           ),
+          const SectionHeader(
+            title: Text('Section Header slide'),
+          ),
+          const SectionHeader.fromText(
+            title: 'Section Header (fromText)',
+          ),
           const ExampleSlide(
             text: 'Slide with no background',
           ), // custom slide with no background

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -58,6 +58,12 @@ class MyHomePage extends StatelessWidget {
                 Container(color: const Color.fromARGB(255, 90, 155, 180)),
           ),
           const CounterSlide(),
+          const BlankSlide(
+            background: ColoredBox(
+              color: Colors.green,
+              child: Text('Blank Slide - This text is from background'),
+            ),
+          ),
           const ExampleSlide(
             text: 'Flutter is Awesome!',
             backgroundColor: Colors.blue,

--- a/lib/src/presentation/src/presentation_widget.dart
+++ b/lib/src/presentation/src/presentation_widget.dart
@@ -30,8 +30,13 @@ import 'package:prides/src/slide/widgets/end_slide.dart';
 ///
 /// *screen here is the area where this widget is displayed.
 ///
-/// Note: It is recomended to use this widget as a complete page
+/// Note1: It is recomended to use this widget as a complete page
 /// as the presentations are usually full screen.
+///
+/// Note2: When a slide doesn't have a background, this widget's background
+/// is considered. And, when this widget doesn't have a background, it will be
+/// like the background is transparent and previous slide will be displayed
+/// due the the usage of stack for slides.
 ///
 /// See also:
 /// * [SlideWidget], a widget that can be used to create a slide.

--- a/lib/src/slide/src/slide_widget.dart
+++ b/lib/src/slide/src/slide_widget.dart
@@ -33,6 +33,7 @@ import 'package:prides/prides.dart';
 ///  a background widget to make a slide.
 /// * [TitleSlide], a template slide that takes title and subtitle as input.
 /// * [SectionHeader], a template slide that takes in just title as input.
+/// * [BlankSlide], a template slide that is blank without any foreground.
 abstract class SlideWidget extends StatelessWidget {
   /// Initializes [key] for subclasses.
   const SlideWidget({super.key});

--- a/lib/src/slide/src/slide_widget.dart
+++ b/lib/src/slide/src/slide_widget.dart
@@ -34,6 +34,8 @@ import 'package:prides/prides.dart';
 /// * [TitleSlide], a template slide that takes title and subtitle as input.
 /// * [SectionHeader], a template slide that takes in just title as input.
 /// * [BlankSlide], a template slide that is blank without any foreground.
+/// * [BackgroundlessSlide], a slide that takes only slide
+/// making background null.
 abstract class SlideWidget extends StatelessWidget {
   /// Initializes [key] for subclasses.
   const SlideWidget({super.key});

--- a/lib/src/slide/src/slide_widget.dart
+++ b/lib/src/slide/src/slide_widget.dart
@@ -47,7 +47,8 @@ abstract class SlideWidget extends StatelessWidget {
   /// Override this method.
   ///
   /// This widget returned by this method will be placed as background
-  /// of that particular slide.
+  /// of that particular slide. Background is wrapped inside
+  /// a [SizedBox.expand] widget so that it stretches to the whole.
   ///
   /// If this method returns null, then the background widget will be empty
   /// i.e. there will be an empty [SizedBox.expand] instead.
@@ -83,7 +84,9 @@ abstract class SlideWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return Stack(
       children: [
-        background() ?? const SizedBox.expand(),
+        SizedBox.expand(
+          child: background(),
+        ),
         slide(context),
       ],
     );

--- a/lib/src/slide/src/slide_widget.dart
+++ b/lib/src/slide/src/slide_widget.dart
@@ -31,6 +31,8 @@ import 'package:prides/prides.dart';
 /// See also:
 /// * [SimpleSlide], a slide that takes a foreground widget and
 ///  a background widget to make a slide.
+/// * [TitleSlide], a template slide that takes title and subtitle as input.
+/// * [SectionHeader], a template slide that takes in just title as input.
 abstract class SlideWidget extends StatelessWidget {
   /// Initializes [key] for subclasses.
   const SlideWidget({super.key});

--- a/lib/src/slide/widgets/backgroundless_slide.dart
+++ b/lib/src/slide/widgets/backgroundless_slide.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:prides/prides.dart';
+
+/// A backgroundless slide that takes only slide as a parameter.
+/// This slide will have a background of the [PresentationWidget].
+/// DONOT prefer to use this widget when [PresentationWidget] background is not
+/// set.
+class BackgroundlessSlide extends SlideWidget {
+  /// Creates a backgroundless slide taking only slide.
+  const BackgroundlessSlide({required Widget slide, super.key})
+      : _slide = slide;
+
+  final Widget _slide;
+
+  @override
+  Widget slide(BuildContext context) => _slide;
+
+  @override
+  Widget? background() => null;
+}

--- a/lib/src/slide/widgets/blank_slide.dart
+++ b/lib/src/slide/widgets/blank_slide.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:prides/prides.dart';
+
+/// A blank slide that contains nothing. Just shows a background.
+///
+/// As this has to override the [slide] method, this slide passes a [SizedBox].
+class BlankSlide extends SlideWidget {
+  /// Creates a blank slide with an option for background widget.
+  const BlankSlide({super.key, Widget? background}) : _background = background;
+
+  final Widget? _background;
+
+  @override
+  Widget slide(BuildContext context) => const SizedBox();
+
+  @override
+  Widget? background() => _background;
+}

--- a/lib/src/slide/widgets/section_header.dart
+++ b/lib/src/slide/widgets/section_header.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:prides/prides.dart';
+
+/// A section header slide that takes in a title widget and wraps
+/// a center around the widget to make a slide from [SlideWidget].
+class SectionHeader extends SlideWidget {
+  /// Creates a Section Header slide using the [title] widget with
+  /// an optional [background] widget.
+  const SectionHeader({
+    required Widget this.title,
+    Widget? background,
+    super.key,
+  })  : _background = background,
+        _titleText = null;
+
+  /// Creates a Section Header slide with just using the string for title.
+  /// It uses [Text] with the [TextTheme.displayMedium] style.
+  ///
+  /// You can always use the defaut constructor of [SectionHeader] for more
+  /// customization.
+  const SectionHeader.fromText({
+    required String title,
+    Widget? background,
+    super.key,
+  })  : _background = background,
+        title = null,
+        _titleText = title;
+
+  /// A title widget shown at the center of the slide
+  final Widget? title;
+
+  /// A text shown in the place of title.
+  /// This is set from the [SectionHeader.fromText] constructor.
+  ///
+  /// This is always be null when [title] is set.
+  final String? _titleText;
+
+  /// Optional background widget
+  final Widget? _background;
+
+  @override
+  Widget slide(BuildContext context) {
+    return Center(
+      child: title ??
+          Text(
+            _titleText!,
+            style: Theme.of(context).textTheme.displayMedium,
+          ),
+    );
+  }
+
+  @override
+  Widget? background() => _background;
+}

--- a/lib/src/slide/widgets/title_slide.dart
+++ b/lib/src/slide/widgets/title_slide.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:prides/prides.dart';
 
-/// This is a title slide that takes a title and an optional sub title
+/// This is a title slide that takes a title and an optional subtitle
 /// to make a slide from [SlideWidget].
 ///
-/// When a sub title is null, only title is shown
+/// The gap between the title and subtitle is of height 16.
 ///
-/// The gap between the title and sub title is of height 16.
+/// If there is no need of [subtitle], use the [SectionHeader] slide.
 class TitleSlide extends SlideWidget {
   /// Creates a title slide using the [title] and [subtitle] widgets
   /// with an optional background widget [background].
@@ -15,14 +15,14 @@ class TitleSlide extends SlideWidget {
   /// - [TitleSlide.fromText] where we can pass just string.
   const TitleSlide({
     required Widget this.title,
-    this.subtitle,
+    required Widget this.subtitle,
     Widget? background,
     super.key,
   })  : _background = background,
         _titleText = null,
         _subtitleText = null;
 
-  /// Creates a title slide with only string of title and sub title.
+  /// Creates a title slide with only string of title and subtitle.
   /// It uses the [TextTheme] from the context and and set the:
   /// - [title] with [TextTheme.displayMedium]
   /// - [subtitle] with [TextTheme.titleMedium]
@@ -31,7 +31,7 @@ class TitleSlide extends SlideWidget {
   /// customization.
   const TitleSlide.fromText({
     required String title,
-    String? subtitle,
+    required String subtitle,
     Widget? background,
     super.key,
   })  : _background = background,
@@ -56,13 +56,12 @@ class TitleSlide extends SlideWidget {
   /// This is set from the [TitleSlide.fromText] constructor.
   ///
   /// This is always null when [subtitle] is set.
-  /// This can be null even when [subtitle] is null.
   final String? _subtitleText;
 
   /// Optional background widget
   final Widget? _background;
 
-  /// A constant height to be set as a gap between title and sub title
+  /// A constant height to be set as a gap between title and subtitle
   double get _height => 16;
 
   /// A sized box with constant [_height]
@@ -70,8 +69,6 @@ class TitleSlide extends SlideWidget {
 
   @override
   Widget slide(BuildContext context) {
-    // when a sub title from all constructors are null, we show no subtitle
-    final hasSubtitle = !(subtitle == null && _subtitleText == null);
     return Center(
       child: Column(
         mainAxisSize: MainAxisSize.min,
@@ -81,13 +78,12 @@ class TitleSlide extends SlideWidget {
                 _titleText!,
                 style: Theme.of(context).textTheme.displayMedium,
               ),
-          if (hasSubtitle) _gap,
-          if (hasSubtitle)
-            subtitle ??
-                Text(
-                  _subtitleText!,
-                  style: Theme.of(context).textTheme.titleMedium,
-                ),
+          _gap,
+          subtitle ??
+              Text(
+                _subtitleText!,
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
         ],
       ),
     );

--- a/lib/src/slide/widgets/widgets.dart
+++ b/lib/src/slide/widgets/widgets.dart
@@ -1,4 +1,5 @@
 // export 'end_slide.dart';
+export 'backgroundless_slide.dart';
 export 'blank_slide.dart';
 export 'section_header.dart';
 export 'simple_slide.dart';

--- a/lib/src/slide/widgets/widgets.dart
+++ b/lib/src/slide/widgets/widgets.dart
@@ -1,4 +1,5 @@
 // export 'end_slide.dart';
+export 'blank_slide.dart';
 export 'section_header.dart';
 export 'simple_slide.dart';
 export 'title_slide.dart';

--- a/lib/src/slide/widgets/widgets.dart
+++ b/lib/src/slide/widgets/widgets.dart
@@ -1,3 +1,4 @@
 // export 'end_slide.dart';
+export 'section_header.dart';
 export 'simple_slide.dart';
 export 'title_slide.dart';

--- a/test/slides/widgets/backgroundless_slide_test.dart
+++ b/test/slides/widgets/backgroundless_slide_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prides/prides.dart';
+
+import 'widgets_test_helper.dart';
+
+void main() {
+  testWidgets('backgroundless slide test', (tester) async {
+    const slideKey = Key('slideWidget');
+    final slide = Container(key: slideKey);
+    await WidgetsTestHelper.pumpApp(
+      tester,
+      BackgroundlessSlide(slide: slide),
+    );
+
+    // Expect: background widget
+    expect(find.byKey(slideKey), findsOneWidget);
+  });
+}

--- a/test/slides/widgets/backgroundless_slide_test.dart
+++ b/test/slides/widgets/backgroundless_slide_test.dart
@@ -8,12 +8,19 @@ void main() {
   testWidgets('backgroundless slide test', (tester) async {
     const slideKey = Key('slideWidget');
     final slide = Container(key: slideKey);
-    await WidgetsTestHelper.pumpApp(
-      tester,
-      BackgroundlessSlide(slide: slide),
-    );
+    final widget = BackgroundlessSlide(slide: slide);
+    await WidgetsTestHelper.pumpApp(tester, widget);
 
-    // Expect: background widget
+    // Expect: slide widget
     expect(find.byKey(slideKey), findsOneWidget);
+
+    // Expect: slide
+    final context = WidgetsTestHelper.mockContext(tester);
+    final slideResult = widget.slide(context);
+    expect(slideResult, slide);
+
+    // Expect: backgrund to be null
+    final backgroundResult = widget.background();
+    expect(backgroundResult, null);
   });
 }

--- a/test/slides/widgets/blank_slide_test.dart
+++ b/test/slides/widgets/blank_slide_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prides/prides.dart';
+
+import 'widgets_test_helper.dart';
+
+void main() {
+  testWidgets('blank slide test', (tester) async {
+    const backgroundKey = Key('backgroundWidget');
+    final background = Container(key: backgroundKey);
+    await WidgetsTestHelper.pumpApp(
+      tester,
+      BlankSlide(background: background),
+    );
+
+    // Expect: background widget
+    expect(find.byKey(backgroundKey), findsOneWidget);
+  });
+}

--- a/test/slides/widgets/blank_slide_test.dart
+++ b/test/slides/widgets/blank_slide_test.dart
@@ -8,12 +8,19 @@ void main() {
   testWidgets('blank slide test', (tester) async {
     const backgroundKey = Key('backgroundWidget');
     final background = Container(key: backgroundKey);
-    await WidgetsTestHelper.pumpApp(
-      tester,
-      BlankSlide(background: background),
-    );
+    final widget = BlankSlide(background: background);
+    await WidgetsTestHelper.pumpApp(tester, widget);
 
     // Expect: background widget
     expect(find.byKey(backgroundKey), findsOneWidget);
+
+    // Expect: slide to be sizedbox
+    final context = WidgetsTestHelper.mockContext(tester);
+    final slideResult = widget.slide(context);
+    expect(slideResult, isA<SizedBox>());
+
+    // Expect: backgrund
+    final backgroundResult = widget.background();
+    expect(backgroundResult, background);
   });
 }

--- a/test/slides/widgets/section_header_test.dart
+++ b/test/slides/widgets/section_header_test.dart
@@ -8,38 +8,32 @@ void main() {
   const titleKey = Key('titleWidget');
   final title = Container(key: titleKey);
   const titleText = 'Title';
-  const subtitleKey = Key('subtitleWidget');
-  final subtitle = Container(key: subtitleKey);
-  const subtitleText = 'Subtitle';
   const backgroundKey = Key('backgroundWidget');
   final background = Container(key: backgroundKey);
 
-  group('title slide test', () {
+  group('section header slide test', () {
     testWidgets('with default constructor', (tester) async {
       await WidgetsTestHelper.pumpApp(
         tester,
-        TitleSlide(title: title, subtitle: subtitle, background: background),
+        SectionHeader(title: title, background: background),
       );
 
-      // Expect: title, subtitle and background widgets
+      // Expect: title and background widgets
       expect(find.byKey(titleKey), findsOneWidget);
-      expect(find.byKey(subtitleKey), findsOneWidget);
       expect(find.byKey(backgroundKey), findsOneWidget);
     });
 
     testWidgets('with fromText constructor', (tester) async {
       await WidgetsTestHelper.pumpApp(
         tester,
-        TitleSlide.fromText(
+        SectionHeader.fromText(
           title: titleText,
-          subtitle: subtitleText,
           background: background,
         ),
       );
 
-      // Expect: title text, subtitle text and background widgets
+      // Expect: title text and background widgets
       expect(find.text(titleText), findsOneWidget);
-      expect(find.text(subtitleText), findsOneWidget);
       expect(find.byKey(backgroundKey), findsOneWidget);
     });
   });

--- a/test/slides/widgets/simple_slide_test.dart
+++ b/test/slides/widgets/simple_slide_test.dart
@@ -10,13 +10,20 @@ void main() {
     final slide = Container(key: slideKey);
     const backgroundKey = Key('backgroundWidget');
     final background = Container(key: backgroundKey);
-    await WidgetsTestHelper.pumpApp(
-      tester,
-      SimpleSlide(slide: slide, background: background),
-    );
+    final widget = SimpleSlide(slide: slide, background: background);
+    await WidgetsTestHelper.pumpApp(tester, widget);
 
     // Expect: slide and background widgets
     expect(find.byKey(slideKey), findsOneWidget);
     expect(find.byKey(backgroundKey), findsOneWidget);
+
+    // Expect: slide
+    final context = WidgetsTestHelper.mockContext(tester);
+    final slideResult = widget.slide(context);
+    expect(slideResult, slide);
+
+    // Expect: backgrund
+    final backgroundResult = widget.background();
+    expect(backgroundResult, background);
   });
 }

--- a/test/slides/widgets/widgets_test_helper.dart
+++ b/test/slides/widgets/widgets_test_helper.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class WidgetsTestHelper {
+  /// Pump app for testing widgets. This pumps the app with the [widget]
+  /// using the [tester]
   static Future<void> pumpApp(
     WidgetTester tester,
     Widget widget,
@@ -13,5 +15,11 @@ class WidgetsTestHelper {
         ),
       ),
     );
+  }
+
+  /// Returns the mock context using [tester].
+  /// Ensure [pumpApp] is already called before.
+  static BuildContext mockContext(WidgetTester tester) {
+    return tester.element(find.byType(Material));
   }
 }


### PR DESCRIPTION
This PR adds new widgets - template slides (`SectionHeader`, `BlankSlide` and `BackgroundlessSlide`).

# Description

> All the template slides tracking is now in an issue #3.

This is still in draft, but there are some template slides that needs to be added to the package. The status of the widgets added is:

- [x] SectionHeader
- [x] BlankSlide
- [x] BackgroundlessSlide

## Checks

<!-- Tick all applicable checkbox by with `[x]` else mark it with `[-]`-->

- [x] Updated/Added the relevant tests and checked them before PR
- [x] Updated/Added all the documentation changes
- [x] Updated/Added the relevant examples in the `/examples` folder

## Breaking Change

- `TitleSlide` now requires `subtitle` that was optional before.
- `SlideWidget`'s `background` now is now wrapped inside a `SizedBox.expand`. This is because, we should not have a partial background slide when widgets like text are passed inside a coloured box or container.
