### PR TITLE
feat: Slide Change callback in `PresentationWidget`

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -26,6 +26,10 @@ class MyHomePage extends StatelessWidget {
         background: const ColoredBox(
           color: Color.fromARGB(255, 113, 61, 173),
         ), // a one color background for whole presentation
+        onSlideChange: (value) {
+          debugPrint('currentSlide: ${value.data.slide}, '
+              'previousSlide: ${value.data.previousSlide}');
+        },
         slides: [
           const CustomTitleSlide(), // slide in content/title_slide.dart
           const TitleSlide(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -26,9 +26,9 @@ class MyHomePage extends StatelessWidget {
         background: const ColoredBox(
           color: Color.fromARGB(255, 113, 61, 173),
         ), // a one color background for whole presentation
-        onSlideChange: (value) {
-          debugPrint('currentSlide: ${value.data.slide}, '
-              'previousSlide: ${value.data.previousSlide}');
+        onSlideChange: (data) {
+          debugPrint('currentSlide: ${data.slide}, '
+              'previousSlide: ${data.previousSlide}');
         },
         slides: [
           const CustomTitleSlide(), // slide in content/title_slide.dart

--- a/lib/src/presentation/presentation.dart
+++ b/lib/src/presentation/presentation.dart
@@ -1,1 +1,2 @@
 export './src/presentation_widget.dart';
+export 'src/slide_change.dart';

--- a/lib/src/presentation/src/presentation_widget.dart
+++ b/lib/src/presentation/src/presentation_widget.dart
@@ -58,7 +58,20 @@ class PresentationWidget extends StatefulWidget {
   /// It will displayed when a slide doesn't have a background.
   final Widget? background;
 
-  final ValueChanged<SlideChangeEvent>? onSlideChange;
+  /// An event callback when a slide is changed. The data passed in this
+  /// callback is [SlideChangeData]. The callback happens only when
+  /// a slide is changed. The index of slides start from 1.
+  /// current slide value is (slidesLength + 1) when reaching the
+  /// end of the presentation slide.
+  ///
+  /// Usage:
+  /// ```dart
+  /// PresentationWidget(
+  ///   onSlideChange: (data) => doSomething,
+  ///   slides: [...],
+  /// ),
+  /// ```
+  final ValueChanged<SlideChangeData>? onSlideChange;
 
   @override
   State<PresentationWidget> createState() => _PresentationWidgetState();
@@ -78,7 +91,8 @@ class _PresentationWidgetState extends State<PresentationWidget> {
   void _initialize() {
     _currentSlide = ValueNotifier(0);
     _focusNode = FocusNode();
-    slideChangeData = SlideChangeData(slide: _currentSlide.value);
+    // + 1 is for the index to start from 1
+    slideChangeData = SlideChangeData(slide: _currentSlide.value + 1);
     _currentSlide.addListener(_slideChangeListener);
   }
 
@@ -97,9 +111,10 @@ class _PresentationWidgetState extends State<PresentationWidget> {
   }
 
   void _slideChangeListener() {
-    slideChangeData.slide = _currentSlide.value;
+    // + 1 is for the index to start from 1
+    slideChangeData.slide = _currentSlide.value + 1;
     if (widget.onSlideChange != null) {
-      widget.onSlideChange!.call(SlideChangeEvent(data: slideChangeData));
+      widget.onSlideChange!.call(slideChangeData);
     }
   }
 

--- a/lib/src/presentation/src/presentation_widget.dart
+++ b/lib/src/presentation/src/presentation_widget.dart
@@ -48,6 +48,7 @@ class PresentationWidget extends StatefulWidget {
     required this.slides,
     super.key,
     this.background,
+    this.onSlideChange,
   }) : assert(slides.length > 0, 'slides cannot be empty');
 
   /// The list of slides made from or using [SlideWidget] to present.
@@ -56,6 +57,8 @@ class PresentationWidget extends StatefulWidget {
   /// The background widget for the presentation.
   /// It will displayed when a slide doesn't have a background.
   final Widget? background;
+
+  final ValueChanged<SlideChangeEvent>? onSlideChange;
 
   @override
   State<PresentationWidget> createState() => _PresentationWidgetState();
@@ -66,19 +69,38 @@ class _PresentationWidgetState extends State<PresentationWidget> {
   ///
   /// it advances or reverses from the methods
   /// [_advanceSlide] and [_reverseSlide] respectively.
-  late int _currentSlide;
+  late ValueNotifier<int> _currentSlide;
 
   late FocusNode _focusNode;
 
+  late SlideChangeData slideChangeData;
+
   void _initialize() {
-    _currentSlide = 0;
+    _currentSlide = ValueNotifier(0);
     _focusNode = FocusNode();
+    slideChangeData = SlideChangeData(slide: _currentSlide.value);
+    _currentSlide.addListener(_slideChangeListener);
   }
 
   @override
   void initState() {
     super.initState();
     _initialize();
+  }
+
+  @override
+  void dispose() {
+    _currentSlide
+      ..removeListener(_slideChangeListener)
+      ..dispose();
+    super.dispose();
+  }
+
+  void _slideChangeListener() {
+    slideChangeData.slide = _currentSlide.value;
+    if (widget.onSlideChange != null) {
+      widget.onSlideChange!.call(SlideChangeEvent(data: slideChangeData));
+    }
   }
 
   /// increases the [_currentSlide] by 1
@@ -88,8 +110,8 @@ class _PresentationWidgetState extends State<PresentationWidget> {
   /// - if it returns true, it will stop the slide from advancing.
   /// - if it returns false, it will advance the slide normally.
   void _advanceSlide() {
-    if (_currentSlide < widget.slides.length) {
-      final controller = widget.slides[_currentSlide].controller;
+    if (_currentSlide.value < widget.slides.length) {
+      final controller = widget.slides[_currentSlide.value].controller;
       if (controller != null) {
         final stopAdvance = controller.advanceSlide();
         if (stopAdvance) {
@@ -97,7 +119,7 @@ class _PresentationWidgetState extends State<PresentationWidget> {
         }
       }
       setState(() {
-        _currentSlide++;
+        _currentSlide.value++;
       });
     }
   }
@@ -109,9 +131,9 @@ class _PresentationWidgetState extends State<PresentationWidget> {
   /// - if it returns true, it will stop the slide from reversing.
   /// - if it returns false, it will reverse the slide normally.
   void _reverseSlide() {
-    if (_currentSlide > 0) {
-      if (_currentSlide < widget.slides.length) {
-        final controller = widget.slides[_currentSlide].controller;
+    if (_currentSlide.value > 0) {
+      if (_currentSlide.value < widget.slides.length) {
+        final controller = widget.slides[_currentSlide.value].controller;
         if (controller != null) {
           final stopReverse = controller.reverseSlide();
           if (stopReverse) {
@@ -120,7 +142,7 @@ class _PresentationWidgetState extends State<PresentationWidget> {
         }
       }
       setState(() {
-        _currentSlide--;
+        _currentSlide.value--;
       });
     }
   }
@@ -169,7 +191,7 @@ class _PresentationWidgetState extends State<PresentationWidget> {
               (index) {
                 // if the slide position is later to the current slide,
                 // we return a blank widget to display nothing.
-                if (index - 1 > _currentSlide) {
+                if (index - 1 > _currentSlide.value) {
                   return const SizedBox.shrink();
                 }
                 // show the end slide after all the slides (topmost)
@@ -190,7 +212,7 @@ class _PresentationWidgetState extends State<PresentationWidget> {
                 return Stack(
                   children: [
                     Opacity(
-                      opacity: _currentSlide == index - 1 ? 1 : 0,
+                      opacity: _currentSlide.value == index - 1 ? 1 : 0,
                       child: widget.slides[index - 1],
                     ),
                   ],

--- a/lib/src/presentation/src/slide_change.dart
+++ b/lib/src/presentation/src/slide_change.dart
@@ -1,0 +1,24 @@
+import 'package:meta/meta.dart';
+
+@immutable
+class SlideChangeEvent {
+  const SlideChangeEvent({required this.data});
+
+  final SlideChangeData data;
+}
+
+class SlideChangeData {
+  SlideChangeData({required int slide}) : _slide = slide;
+  int _slide;
+  int? _previousSlide;
+
+  @internal
+  set slide(int slide) {
+    _previousSlide = _slide;
+    _slide = slide;
+  }
+
+  int get slide => _slide;
+
+  int? get previousSlide => _previousSlide;
+}

--- a/lib/src/presentation/src/slide_change.dart
+++ b/lib/src/presentation/src/slide_change.dart
@@ -1,24 +1,32 @@
 import 'package:meta/meta.dart';
+import 'package:prides/prides.dart';
 
-@immutable
-class SlideChangeEvent {
-  const SlideChangeEvent({required this.data});
-
-  final SlideChangeData data;
-}
-
+/// Data that is used for event callback from the [PresentationWidget] when
+/// a slide is changed. It gives the current slide ([slide]) and
+/// previous slide ([previousSlide]).
 class SlideChangeData {
+  /// creates a slide change data. This is mostly used by [PresentationWidget]
+  /// internally and is created only once per the widget.
+  @internal
   SlideChangeData({required int slide}) : _slide = slide;
+
+  /// keeps track of the current slide the user is in.
   int _slide;
+
+  /// keeps track of the previous slide the user was in.
   int? _previousSlide;
 
+  /// sets the current slide to the given value, while setting the
+  /// previous slide value to the already existing slide value.
   @internal
   set slide(int slide) {
     _previousSlide = _slide;
     _slide = slide;
   }
 
+  /// get the current slide index
   int get slide => _slide;
 
+  /// get the previous slide index
   int? get previousSlide => _previousSlide;
 }

--- a/test/presentation/slide_change_test.dart
+++ b/test/presentation/slide_change_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:prides/prides.dart';
+
+void main() {
+  group('slide change data - ', () {
+    test('initialization', () {
+      const initialSlide = 1;
+      final slideChangeData = SlideChangeData(slide: initialSlide);
+      expect(slideChangeData.slide, initialSlide);
+      expect(slideChangeData.previousSlide, null);
+    });
+
+    test('set slide', () {
+      const initialSlide = 1;
+      final slideChangeData = SlideChangeData(slide: initialSlide);
+      // ignore: cascade_invocations
+      slideChangeData.slide = initialSlide + 1;
+      expect(slideChangeData.slide, initialSlide + 1);
+      expect(slideChangeData.previousSlide, initialSlide);
+    });
+  });
+}

--- a/test/prides_test.dart
+++ b/test/prides_test.dart
@@ -291,4 +291,28 @@ void main() {
       expect(tester.widget<Opacity>(parentOpacityTwo).opacity, 1);
     },
   );
+
+  testWidgets(
+    'slide change callback',
+    (tester) async {
+      late int currentSlide;
+      late int previousSlide;
+      final presentationWidget = PresentationWidget(
+        slides: const [MockSlideWidget(), MockSlideWidget()],
+        onSlideChange: (value) {
+          currentSlide = value.slide;
+          previousSlide = value.previousSlide!;
+        },
+      );
+      await pumpApp(tester, presentationWidget);
+
+      // advance - go to the second slide
+      await tester.tap(find.byType(PresentationWidget));
+      await tester.pumpAndSettle();
+
+      // Expect the current slide and previous slide
+      expect(currentSlide, 2);
+      expect(previousSlide, 1);
+    },
+  );
 }


### PR DESCRIPTION
this PR exposes an option for callback in presentation widget when a slide is changed. The data received will contain the current slide and previous slide data.

It changes the way we keep track of the current slide from just integer to value `ValueNotifier` so that we can listen to slide changes and call the callback easily.

Closes #4

## Description

now, with this PR, we can have an event callback to the `PresentationWidget` to know the current slide.

Example:
```dart
PresentationWidget(
  onSlideChange: (data) => debugPrint(data.slide),
  ...
),
```

## Checks

<!-- Tick all applicable checkbox by with `[x]` else mark it with `[-]`-->

- [x] Updated/Added the relevant tests and checked them before PR
- [x] Updated/Added all the documentation changes
- [x] Updated/Added the relevant examples in the `/examples` folder
