### PR TITLE
fix: extra stack in presentation widget

### DIFF
--- a/lib/src/presentation/src/presentation_widget.dart
+++ b/lib/src/presentation/src/presentation_widget.dart
@@ -223,14 +223,11 @@ class _PresentationWidgetState extends State<PresentationWidget> {
                 }
                 // if slide position is before to the current slide,
                 // we add the widges in stack on top of another with
-                // the current slide being at the top, them being transparent.
-                return Stack(
-                  children: [
-                    Opacity(
-                      opacity: _currentSlide.value == index - 1 ? 1 : 0,
-                      child: widget.slides[index - 1],
-                    ),
-                  ],
+                // the current slide being at the top,
+                // rest being transparent.
+                return Opacity(
+                  opacity: _currentSlide.value == index - 1 ? 1 : 0,
+                  child: widget.slides[index - 1],
                 );
               },
             ),


### PR DESCRIPTION
Instead of reaturning a normal widget in generating widget, we are returning a stack that is being placed inside a stack. This commit removes the condition and returns just the widget instead of another stack.

## Checks

<!-- Tick all applicable checkbox by with `[x]` else mark it with `[-]`-->

- [x] Updated/Added the relevant tests and checked them before PR
- [-] Updated/Added all the documentation changes
- [-] Updated/Added the relevant examples in the `/examples` folder