### PR TITLE
feat: Add option to choose a size / resolution for slides

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,22 @@ PresentationWidget(
 ),
 ```
 
+We can customize resolution of slides:
+```dart
+PresentationWidget(
+    slides: slideList, // required
+    slideSize: SlideSize.standardBig, // 4:3 aspect ratio (16:9 is default when not specified)
+),
+```
+
+We can specify how slides fits inside the widget:
+```dart
+PresentationWidget(
+    slides: slideList, // required
+    slideFit: BoxFit.fill, // defaults to BoxFit.cover when not specified
+),
+```
+
 ### SlideWidget
 
 It is an abstract class exposed from this package. Extend and implement this class to use in the `PresentationWidget`.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -32,7 +32,8 @@ class MyHomePage extends StatelessWidget {
           debugPrint('currentSlide: ${data.slide}, '
               'previousSlide: ${data.previousSlide}');
         },
-        slideSize: SlideSize.widescreenSmall,
+        slideSize: SlideSize.widescreenBig,
+        slideFit: BoxFit.contain,
         slides: [
           const CustomTitleSlide(), // slide in content/title_slide.dart
           const TitleSlide(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:prides/prides.dart';
+
 import './content/content.dart';
 
 class MyApp extends StatelessWidget {
@@ -31,6 +32,7 @@ class MyHomePage extends StatelessWidget {
           debugPrint('currentSlide: ${data.slide}, '
               'previousSlide: ${data.previousSlide}');
         },
+        slideSize: SlideSize.widescreenSmall,
         slides: [
           const CustomTitleSlide(), // slide in content/title_slide.dart
           const TitleSlide(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -32,8 +32,8 @@ class MyHomePage extends StatelessWidget {
           debugPrint('currentSlide: ${data.slide}, '
               'previousSlide: ${data.previousSlide}');
         },
-        slideSize: SlideSize.widescreenBig,
-        slideFit: BoxFit.contain,
+        slideSize: SlideSize.widescreenSmall, // just to showcase
+        slideFit: BoxFit.scaleDown, // just to showcase
         slides: [
           const CustomTitleSlide(), // slide in content/title_slide.dart
           const TitleSlide(

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -95,10 +95,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: c94db23593b89766cda57aab9ac311e3616cf87c6fa4e9749df032f66f30dcb8
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.14"
+    version: "0.12.15"
   material_color_utilities:
     dependency: transitive
     description:
@@ -111,10 +111,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "12307e7f0605ce3da64cf0db90e5fcab0869f3ca03f76be6bb2991ce0a55e82b"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   path:
     dependency: transitive
     description:
@@ -179,10 +179,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "6182294da5abf431177fccc1ee02401f6df30f766bc6130a0852c6b6d7ee6b2d"
+      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.18"
+    version: "0.5.1"
   vector_math:
     dependency: transitive
     description:
@@ -192,5 +192,5 @@ packages:
     source: hosted
     version: "2.1.4"
 sdks:
-  dart: ">=2.19.2 <4.0.0"
+  dart: ">=3.0.0-0 <4.0.0"
   flutter: ">=3.0.0"

--- a/lib/src/presentation/presentation.dart
+++ b/lib/src/presentation/presentation.dart
@@ -1,2 +1,3 @@
 export './src/presentation_widget.dart';
 export 'src/slide_change.dart';
+export 'src/slide_size.dart';

--- a/lib/src/presentation/src/presentation_widget.dart
+++ b/lib/src/presentation/src/presentation_widget.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:prides/prides.dart';
-
 import 'package:prides/src/slide/widgets/end_slide.dart';
 
 /// A widget that can present the slides.
@@ -11,6 +10,11 @@ import 'package:prides/src/slide/widgets/end_slide.dart';
 /// to [background] that is displayed when a slide doesn't have
 /// a background. This enables use of a common background all over
 /// the presentation.
+///
+/// By default, the widget makes the [slides] resolution to
+/// [SlideSize.widescreenBig] (1920x1080). The [slideSize] can be used to
+/// set preferred resolution. Also, packaged along with this comes an option
+/// on how to fit the slide in this widget using [slideFit].
 ///
 /// It is best to use a [Material] widget as a parent of this widget.
 /// And always use this widget inside a [MaterialApp].
@@ -49,7 +53,8 @@ class PresentationWidget extends StatefulWidget {
     super.key,
     this.background,
     this.onSlideChange,
-    // Todo(immadisairaj): try to add an option for ratio, free size
+    this.slideSize = SlideSize.widescreenBig,
+    this.slideFit = BoxFit.contain,
   }) : assert(slides.length > 0, 'slides cannot be empty');
 
   /// The list of slides made from or using [SlideWidget] to present.
@@ -73,6 +78,12 @@ class PresentationWidget extends StatefulWidget {
   /// ),
   /// ```
   final ValueChanged<SlideChangeData>? onSlideChange;
+
+  /// Resolution of slide in the presentation widget.
+  final SlideSize slideSize;
+
+  /// How to inscribe the slide into the space allocated during layout.
+  final BoxFit slideFit;
 
   @override
   State<PresentationWidget> createState() => _PresentationWidgetState();
@@ -204,11 +215,11 @@ class _PresentationWidgetState extends State<PresentationWidget> {
           child: ColoredBox(
             // show black color for extra space while presenting
             color: Colors.black,
-            child: Center(
-              // TODO(immadisairaj): add more customizations for aspect ratios
-              child: AspectRatio(
-                aspectRatio: 16 / 9,
-                // TODO(immadisairaj): Try to scale content based on ratio
+            child: FittedBox(
+              fit: widget.slideFit,
+              child: SizedBox(
+                width: widget.slideSize.width + 0.0,
+                height: widget.slideSize.height + 0.0,
                 child: Stack(
                   children: List<Widget>.generate(
                     widget.slides.length + 2, // +2 for background and end slide

--- a/lib/src/presentation/src/presentation_widget.dart
+++ b/lib/src/presentation/src/presentation_widget.dart
@@ -49,6 +49,7 @@ class PresentationWidget extends StatefulWidget {
     super.key,
     this.background,
     this.onSlideChange,
+    // Todo(immadisairaj): try to add an option for ratio, free size
   }) : assert(slides.length > 0, 'slides cannot be empty');
 
   /// The list of slides made from or using [SlideWidget] to present.
@@ -200,39 +201,50 @@ class _PresentationWidgetState extends State<PresentationWidget> {
         onKey: _onKeyEvent,
         child: GestureDetector(
           onTapDown: _onTapDownEvent,
-          child: Stack(
-            children: List<Widget>.generate(
-              widget.slides.length + 2, // +2 for background and end slide
-              (index) {
-                // if the slide position is later to the current slide,
-                // we return a blank widget to display nothing.
-                if (index - 1 > _currentSlide.value) {
-                  return const SizedBox.shrink();
-                }
-                // show the end slide after all the slides (topmost)
-                if (index - 1 == widget.slides.length) {
-                  // end of the presentation
-                  return const EndSlide(
-                    key: ValueKey('EndSlide'),
-                  );
-                }
-                // show the presentation background at
-                // the bottom most in the stack
-                if (index == 0) {
-                  return SizedBox.expand(child: widget.background);
-                }
-                // if slide position is before to the current slide,
-                // we add the widges in stack on top of another with
-                // the current slide being at the top, them being transparent.
-                return Stack(
-                  children: [
-                    Opacity(
-                      opacity: _currentSlide.value == index - 1 ? 1 : 0,
-                      child: widget.slides[index - 1],
-                    ),
-                  ],
-                );
-              },
+          child: ColoredBox(
+            // show black color for extra space while presenting
+            color: Colors.black,
+            child: Center(
+              // TODO(immadisairaj): add more customizations for aspect ratios
+              child: AspectRatio(
+                aspectRatio: 16 / 9,
+                // TODO(immadisairaj): Try to scale content based on ratio
+                child: Stack(
+                  children: List<Widget>.generate(
+                    widget.slides.length + 2, // +2 for background and end slide
+                    (index) {
+                      // if the slide position is later to the current slide,
+                      // we return a blank widget to display nothing.
+                      if (index - 1 > _currentSlide.value) {
+                        return const SizedBox.shrink();
+                      }
+                      // show the end slide after all the slides (topmost)
+                      if (index - 1 == widget.slides.length) {
+                        // end of the presentation
+                        return const EndSlide(
+                          key: ValueKey('EndSlide'),
+                        );
+                      }
+                      // show the presentation background at
+                      // the bottom most in the stack
+                      if (index == 0) {
+                        return SizedBox.expand(child: widget.background);
+                      }
+                      // if slide position is before to the current slide,
+                      // we add the widges in stack on top of another with
+                      // the current slide being at the top, them being transparent.
+                      return Stack(
+                        children: [
+                          Opacity(
+                            opacity: _currentSlide.value == index - 1 ? 1 : 0,
+                            child: widget.slides[index - 1],
+                          ),
+                        ],
+                      );
+                    },
+                  ),
+                ),
+              ),
             ),
           ),
         ),

--- a/lib/src/presentation/src/presentation_widget.dart
+++ b/lib/src/presentation/src/presentation_widget.dart
@@ -230,52 +230,53 @@ class _PresentationWidgetState extends State<PresentationWidget> {
                 height: widget.slideSize.height + 0.0,
                 child: Stack(
                   children: List<Widget>.generate(
-                    widget.slides.length + 2, // +2 for background and end slide
-                    (index) {
-                      // if the slide position is later to the current slide,
-                      // we return a blank widget to display nothing.
-                      if (index - 1 > _currentSlide.value) {
-                        return const SizedBox.shrink();
-                      }
-                      // show the end slide after all the slides (topmost)
-                      if (index - 1 == widget.slides.length) {
-                        // end of the presentation
-                        return const EndSlide(
-                          key: ValueKey('EndSlide'),
-                        );
-                      }
-                      // show the presentation background at
-                      // the bottom most in the stack
-                      if (index == 0) {
-                        return SizedBox.expand(child: widget.background);
-                      }
-                      // if slide position is before to the current slide,
-                      // we add the widges in stack on top of another with
-                      // the current slide being at the top,
-                      // rest being transparent.
-                      return Opacity(
-                        opacity: _currentSlide.value == index - 1 ? 1 : 0,
-                        child: widget.slides[index - 1],
-                      );
-                    },
-                  ) +
-                // show the current slide number when is to true
-                // and the current slide is not the end slide
-                // Adding it to the stack so that it is always on top
-                [
-                  if (widget.showSlideNumber &&
-                      _currentSlide.value < widget.slides.length)
-                    Align(
-                      alignment: Alignment.bottomCenter,
-                      child: Padding(
-                        padding: const EdgeInsets.only(bottom: 20),
-                        child: Text(
-                          '${_currentSlide.value + 1}',
-                          style: Theme.of(context).textTheme.labelLarge,
-                        ),
-                      ),
-                    ),
-                ],
+                        widget.slides.length +
+                            2, // +2 for background and end slide
+                        (index) {
+                          // if the slide position is later to the current
+                          // slide, we return a blank widget to display nothing.
+                          if (index - 1 > _currentSlide.value) {
+                            return const SizedBox.shrink();
+                          }
+                          // show the end slide after all the slides (topmost)
+                          if (index - 1 == widget.slides.length) {
+                            // end of the presentation
+                            return const EndSlide(
+                              key: ValueKey('EndSlide'),
+                            );
+                          }
+                          // show the presentation background at
+                          // the bottom most in the stack
+                          if (index == 0) {
+                            return SizedBox.expand(child: widget.background);
+                          }
+                          // if slide position is before to the current slide,
+                          // we add the widges in stack on top of another with
+                          // the current slide being at the top,
+                          // rest being transparent.
+                          return Opacity(
+                            opacity: _currentSlide.value == index - 1 ? 1 : 0,
+                            child: widget.slides[index - 1],
+                          );
+                        },
+                      ) +
+                      // show the current slide number when is to true
+                      // and the current slide is not the end slide
+                      // Adding it to the stack so that it is always on top
+                      [
+                        if (widget.showSlideNumber &&
+                            _currentSlide.value < widget.slides.length)
+                          Align(
+                            alignment: Alignment.bottomCenter,
+                            child: Padding(
+                              padding: const EdgeInsets.only(bottom: 20),
+                              child: Text(
+                                '${_currentSlide.value + 1}',
+                                style: Theme.of(context).textTheme.labelLarge,
+                              ),
+                            ),
+                          ),
+                      ],
                 ),
               ),
             ),

--- a/lib/src/presentation/src/slide_size.dart
+++ b/lib/src/presentation/src/slide_size.dart
@@ -1,0 +1,45 @@
+import 'package:prides/prides.dart';
+
+/// Provides an option to set the slide resolution in the [PresentationWidget].
+///
+/// This class provides a few constant sizes used widely:
+/// [standardSmall], [standardBig], [widescreenSmall], [widescreenBig],
+/// [widescreenOldSmall] and [widescreenOldBig].
+///
+/// Also set a custom size using the [SlideSize] constructor
+class SlideSize {
+  /// creates an object which is utilized by [PresentationWidget] to
+  /// determine the size of a [SlideWidget] while presenting.
+  const SlideSize({required int width, required int height})
+      : _width = width,
+        _height = height;
+
+  /// 4:3 aspect ratio; 960 x 720 pixels
+  static const SlideSize standardSmall = SlideSize(width: 960, height: 720);
+
+  /// 4:3 aspect ratio; 1024 x 768 pixels
+  static const SlideSize standardBig = SlideSize(width: 1024, height: 768);
+
+  /// 16:9 aspect ratio; 960 x 540 pixels
+  static const SlideSize widescreenSmall = SlideSize(width: 960, height: 540);
+
+  /// 16:9 aspect ratio; 1920 x 1080 pixels (default)
+  static const SlideSize widescreenBig = SlideSize(width: 1920, height: 1080);
+
+  /// 16:10 aspect ratio; 960 x 600 pixels
+  static const SlideSize widescreenOldSmall =
+      SlideSize(width: 960, height: 600);
+
+  /// 16:10 aspect ratio; 1920 x 1200 pixels
+  static const SlideSize widescreenOldBig =
+      SlideSize(width: 1920, height: 1200);
+
+  final int _width;
+  final int _height;
+
+  /// get the width of the preferred slide size
+  int get width => _width;
+
+  /// get the height of the preferred slide size
+  int get height => _height;
+}

--- a/test/prides_test.dart
+++ b/test/prides_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:prides/prides.dart';
 import 'package:prides/src/slide/widgets/end_slide.dart';
 
@@ -327,4 +326,79 @@ void main() {
       expect(previousSlide, 1);
     },
   );
+
+  testWidgets('slide size in presentation widget', (tester) async {
+    const slideKey = Key('slideOne');
+    const slide = MockSlideWidget(key: slideKey);
+    final presentationWidget = PresentationWidget(
+      slides: const [slide],
+    );
+    await pumpApp(tester, presentationWidget);
+
+    // Expect the slide having defualt size resolution of 1080p
+    final parentSizedBox = find.ancestor(
+      of: find.byWidget(slide),
+      matching: find.byType(SizedBox),
+    );
+    expect(
+      tester.widget<SizedBox>(parentSizedBox).width,
+      SlideSize.widescreenBig.width,
+    );
+    expect(
+      tester.widget<SizedBox>(parentSizedBox).height,
+      SlideSize.widescreenBig.height,
+    );
+  });
+
+  testWidgets('custom slide size in presentation widget', (tester) async {
+    const slideKey = Key('slideOne');
+    const slide = MockSlideWidget(key: slideKey);
+    const slideSize = SlideSize(width: 900, height: 900);
+    final presentationWidget = PresentationWidget(
+      slides: const [slide],
+      slideSize: slideSize,
+    );
+    await pumpApp(tester, presentationWidget);
+
+    // Expect the slide having defualt size resolution of 1080p
+    final parentSizedBox = find.ancestor(
+      of: find.byWidget(slide),
+      matching: find.byType(SizedBox),
+    );
+    expect(tester.widget<SizedBox>(parentSizedBox).width, slideSize.width);
+    expect(tester.widget<SizedBox>(parentSizedBox).height, slideSize.height);
+  });
+
+  testWidgets('slide fit in presentation widget', (tester) async {
+    const slideKey = Key('slideOne');
+    const slide = MockSlideWidget(key: slideKey);
+    final presentationWidget = PresentationWidget(
+      slides: const [slide],
+    );
+    await pumpApp(tester, presentationWidget);
+
+    // Expect the slide having defualt fit of BoxFit.contain
+    final parentFittedBox = find.ancestor(
+      of: find.byWidget(slide),
+      matching: find.byType(FittedBox),
+    );
+    expect(tester.widget<FittedBox>(parentFittedBox).fit, BoxFit.contain);
+  });
+
+  testWidgets('custom slide fit in presentation widget', (tester) async {
+    const slideKey = Key('slideOne');
+    const slide = MockSlideWidget(key: slideKey);
+    final presentationWidget = PresentationWidget(
+      slides: const [slide],
+      slideFit: BoxFit.fill,
+    );
+    await pumpApp(tester, presentationWidget);
+
+    // Expect the slide having defualt fit of BoxFit.contain
+    final parentFittedBox = find.ancestor(
+      of: find.byWidget(slide),
+      matching: find.byType(FittedBox),
+    );
+    expect(tester.widget<FittedBox>(parentFittedBox).fit, BoxFit.fill);
+  });
 }


### PR DESCRIPTION
There is a problem that the slides don't scale and they can't exactly tell what it is when looking at the big window. This PR makes it possible to set a proper resolution which then scales up or down on changing the window size by keeping it constant on any dimensioned device.

Closes #11 

# Screen Recordings

Before:

https://github.com/immadisairaj/prides/assets/40348358/9bdb8b76-fc1c-49a0-84f7-4321a80cd01e

After:

https://github.com/immadisairaj/prides/assets/40348358/d75cbc1e-0420-4abf-a590-77093235220f


## Checks

<!-- Tick all applicable checkbox by with `[x]` else mark it with `[-]`-->

- [x] Updated/Added the relevant tests and checked them before PR
- [x] Updated/Added all the documentation changes
- [x] Updated/Added the relevant examples in the `/examples` folder

## Breaking Change

No